### PR TITLE
Fix custom_fields method missing for logstasher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,17 @@ language: ruby
 rvm:
   - 2.1.4
   - 2.2.3
+  - 2.4.2
 
 env:
   - "RAILS_VERSION=4.0"
-  - "RAILS_VERSION=3.2"
-  - "RAILS_VERSION=3.1"
-  - "RAILS_VERSION=3.0"
+  - "RAILS_VERSION=4.1"
+  - "RAILS_VERSION=4.2"
+  - "RAILS_VERSION=5.0"
 
 script: bundle exec rspec
+
+matrix:
+  exclude:
+    - rvm: 2.1.4
+      env: RAILS_VERSION=5.0

--- a/Gemfile
+++ b/Gemfile
@@ -3,8 +3,8 @@ source 'https://rubygems.org'
 # Specify your gem's dependencies in logger_instrumentation.gemspec
 gemspec
 
-gem 'rails', "~> #{ENV["RAILS_VERSION"] || "3.2.0"}"
-   
+gem 'rails', "~> #{ENV["RAILS_VERSION"] || "4.0.0"}"
+
 group :test do
   gem 'rcov', :platforms => :mri_18
   gem 'simplecov', :platforms => :mri_19, :require => false

--- a/lib/logger_instrumentation/log_stasher_log_subscriber.rb
+++ b/lib/logger_instrumentation/log_stasher_log_subscriber.rb
@@ -50,8 +50,8 @@ module LoggerInstrumentation
     end
 
     def extract_custom_fields(data)
-      custom_fields = (!::LogStasher.custom_fields.empty? && data.extract!(*::LogStasher.custom_fields)) || {}
-      ::LogStasher.custom_fields.clear
+      custom_fields = (!::LogStasher::CustomFields.custom_fields.empty? && data.extract!(*::LogStasher::CustomFields.custom_fields)) || {}
+      ::LogStasher::CustomFields.custom_fields.clear
       custom_fields
     end
 

--- a/logger_instrumentation.gemspec
+++ b/logger_instrumentation.gemspec
@@ -28,11 +28,11 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_runtime_dependency 'logstasher'
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_runtime_dependency 'logstasher', '~> 1.0.0'
   spec.add_runtime_dependency 'logstash-event', '~> 1.2.0'
-  spec.add_runtime_dependency 'activesupport', '>= 3.0'
+  spec.add_runtime_dependency 'activesupport', '>= 4.0'
 
   spec.add_development_dependency('rspec')
-  spec.add_development_dependency('rails', '>= 3.0')
+  spec.add_development_dependency('rails', '>= 4.0')
 end

--- a/spec/logger_instrumentation/log_subscriber_spec.rb
+++ b/spec/logger_instrumentation/log_subscriber_spec.rb
@@ -5,10 +5,10 @@ describe LoggerInstrumentation::LogSubscriber do
   let(:subscriber) { LoggerInstrumentation::LogSubscriber.new }
 
   let(:message) { "hello world" }
-  let(:format) { '\#{payload[:message]} here I am' }
   let(:event) { ActiveSupport::Notifications::Event.new("info.fidor_application", Time.now, Time.now, 2, Hash.new) }
   let(:severity) { :info }
   let(:logger) { double(Logger) }
+  let(:format) { "#{event.payload[:message]} here I am" }
 
   before do
     allow(subscriber).to receive(:logger).and_return(logger)
@@ -22,7 +22,6 @@ describe LoggerInstrumentation::LogSubscriber do
   end
 
   it "passes formated message to attached logger when format given" do
-    pending
     event.payload[:message] = message
     event.payload[:format] = format
     expect(subscriber.logger).to receive(severity).with("hello world here I am")


### PR DESCRIPTION
@MarcGrimme 

Updated logger_instrumentation with newest version of logstasher and other dependencies (rails, activesupport ~> 4), where it was raising exception due missing `custom_fields` method in logstasher ~ 1.0.0, which was moved to new module.

If you have installed logstasher >= 1.0.0, logger_instrumentation (which uses logstasher 0.9.0) expects `CustomFields` module to be defined in logstasher.

Also this will drop support for rails < 4.

```shell
Could not log "error.logger_instrumentation" event. NoMethodError: undefined method `custom_fields' for LogStasher:Module
Did you mean?  add_custom_fields ["/Users/xxx/.rvm/gems/ruby-2.3.1@xxx-xxx/bundler/gems/logger_instrumentation-...
```